### PR TITLE
Fix dev server hanging at Compiling

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,15 +2,18 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  headers: async () => [
-    {
-      source: "/(.*)",
-      headers: [
-        { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
-        { key: "Cross-Origin-Embedder-Policy", value: "require-corp" },
-      ],
-    },
-  ],
+  headers: async () => {
+    if (process.env.NODE_ENV === "development") return [];
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+          { key: "Cross-Origin-Embedder-Policy", value: "require-corp" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- COOP/COEP headers (`Cross-Origin-Opener-Policy`, `Cross-Origin-Embedder-Policy`) were applied to all routes including in development
- These headers block Next.js HMR WebSocket and dynamic chunk loading, causing the dev server to hang indefinitely at "Compiling..." with 100% CPU
- Fix: skip the headers when `NODE_ENV === "development"` — they're still applied in production where PowerSync needs SharedArrayBuffer

## Test plan
- [x] Run `pnpm dev` and confirm server starts in <1s
- [x] Open `localhost:3000` and confirm page loads without hanging
- [ ] Verify production build still includes the COOP/COEP headers