### PR TITLE
Fix summary page: English translation, colors, and ring display

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,26 +10,26 @@ import { Task } from "@/lib/types";
 type RingMode = "done" | "pending" | "total";
 
 const MODES: { key: RingMode; label: string }[] = [
-  { key: "done", label: "Lo que hice" },
-  { key: "pending", label: "Lo que falta" },
-  { key: "total", label: "Total estimado" },
+  { key: "done", label: "What I did" },
+  { key: "pending", label: "What's left" },
+  { key: "total", label: "Estimated total" },
 ];
 
 const MODE_META: Record<RingMode, { desc: string; statLabel: string; statSub: string }> = {
   done: {
-    desc: "Tareas completadas hoy por categoría",
-    statLabel: "Completadas",
-    statSub: "de hoy",
+    desc: "Tasks completed today by category",
+    statLabel: "Completed",
+    statSub: "today",
   },
   pending: {
-    desc: "Tareas que aún faltan completar hoy",
-    statLabel: "Pendientes",
-    statSub: "quedan por hacer",
+    desc: "Tasks still left to complete today",
+    statLabel: "Pending",
+    statSub: "left to do",
   },
   total: {
-    desc: "Estimado total del día (hechas + pendientes)",
-    statLabel: "Total del día",
-    statSub: "planificadas para hoy",
+    desc: "Estimated total for the day (done + pending)",
+    statLabel: "Total",
+    statSub: "planned for today",
   },
 };
 
@@ -96,7 +96,7 @@ export default function SummaryPage() {
   const doneLife = doneToday.filter((t) => t.balance_category === "life");
 
   return (
-    <AppShell title="Resumen de hoy" onAdd={createTask}>
+    <AppShell title="Today's Summary" onAdd={createTask}>
       <div className="space-y-5">
         {/* Segmented control */}
         <div className="flex gap-0.5 bg-gray-100 rounded-lg p-1">
@@ -127,11 +127,11 @@ export default function SummaryPage() {
         {/* Done today */}
         <section>
           <h2 className="text-sm font-semibold text-gray-700 mb-2">
-            Completadas hoy ({doneToday.length})
+            Completed today ({doneToday.length})
           </h2>
           {doneToday.length === 0 ? (
             <p className="text-xs text-gray-400 py-2">
-              Aún no completaste tareas hoy
+              No tasks completed yet today
             </p>
           ) : (
             <div className="space-y-1">
@@ -143,8 +143,8 @@ export default function SummaryPage() {
                   <span
                     className={`w-2 h-2 rounded-full flex-shrink-0 ${
                       task.balance_category === "work"
-                        ? "bg-[#1D9E75]"
-                        : "bg-[#534AB7]"
+                        ? "bg-[#4F6BED]"
+                        : "bg-[#1D9E75]"
                     }`}
                   />
                   <span className="text-sm text-gray-700 truncate flex-1">
@@ -165,7 +165,7 @@ export default function SummaryPage() {
         <section>
           <div className="flex items-center gap-2 mb-2">
             <h2 className="text-sm font-semibold text-gray-700">
-              Pendientes hoy
+              Pending today
             </h2>
             {activeToday.length > 0 && (
               <span className="text-xs bg-indigo-50 text-indigo-600 px-2 py-0.5 rounded-full font-medium">
@@ -175,7 +175,7 @@ export default function SummaryPage() {
           </div>
           {activeToday.length === 0 ? (
             <p className="text-xs text-gray-400 py-2">
-              Todo listo por hoy
+              All done for today
             </p>
           ) : (
             <div className="space-y-1">
@@ -212,14 +212,14 @@ export default function SummaryPage() {
           <section>
             <div className="flex items-center justify-between mb-2">
               <h2 className="text-sm font-semibold text-gray-700">
-                Mañana ({tomorrowTasks.length})
+                Tomorrow ({tomorrowTasks.length})
               </h2>
               {tomorrowTasks.length > 5 && (
                 <Link
                   href="/planner"
                   className="text-xs text-indigo-600 font-medium"
                 >
-                  Ver todo
+                  See all
                 </Link>
               )}
             </div>
@@ -232,8 +232,8 @@ export default function SummaryPage() {
                   <span
                     className={`w-2 h-2 rounded-full flex-shrink-0 ${
                       task.balance_category === "work"
-                        ? "bg-[#1D9E75]"
-                        : "bg-[#534AB7]"
+                        ? "bg-[#4F6BED]"
+                        : "bg-[#1D9E75]"
                     }`}
                   />
                   <span className="text-sm text-gray-600 truncate">

--- a/src/components/BalanceRing.tsx
+++ b/src/components/BalanceRing.tsx
@@ -9,8 +9,8 @@ interface BalanceRingProps {
 }
 
 const CIRC = 2 * Math.PI * 60;
-const WORK_COLOR = "#1D9E75";
-const LIFE_COLOR = "#534AB7";
+const WORK_COLOR = "#4F6BED";
+const LIFE_COLOR = "#1D9E75";
 
 export function BalanceRing({
   workCount,
@@ -75,8 +75,22 @@ export function BalanceRing({
           )}
         </svg>
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
-          <div className="text-2xl font-medium text-gray-900">{workPct}%</div>
-          <div className="text-xs text-gray-500">work</div>
+          {total === 0 ? (
+            <>
+              <div className="text-2xl font-medium text-gray-400">—</div>
+              <div className="text-xs text-gray-400">no tasks</div>
+            </>
+          ) : workPct >= lifePct ? (
+            <>
+              <div className="text-2xl font-medium text-gray-900">{workPct}%</div>
+              <div className="text-xs text-gray-500">work</div>
+            </>
+          ) : (
+            <>
+              <div className="text-2xl font-medium text-gray-900">{lifePct}%</div>
+              <div className="text-xs text-gray-500">life</div>
+            </>
+          )}
         </div>
       </div>
 
@@ -99,7 +113,7 @@ export function BalanceRing({
         </div>
         <div className="bg-gray-50 rounded-lg px-3 py-2.5">
           <div className="text-xs text-gray-500">Balance</div>
-          <div className="text-lg font-medium text-gray-900">{workPct}/{lifePct}</div>
+          <div className="text-lg font-medium text-gray-900">{workPct}% / {lifePct}%</div>
           <div className="text-xs text-gray-400">work / life</div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Translate all Spanish UI text to English (tabs, headers, empty states, labels)
- Fix work/life category colors: work is now blue (`#4F6BED`), life is green (`#1D9E75`)
- Ring center now shows the dominant category percentage (e.g. "100% life" instead of always showing work %)
- Balance card displays "0% / 100%" format instead of confusing "0/100"

## Test plan
- [ ] Open the Summary page and verify all text is in English
- [ ] Complete a "life" task and verify the dot color is green and ring shows "100% life"
- [ ] Complete a "work" task and verify the dot color is blue
- [ ] Verify balance card shows percentage format (e.g. "50% / 50%")
- [ ] Check empty state shows "—" with "no tasks" in ring center