### PR TITLE
feat: idea promotion to task

### DIFF
--- a/src/app/brainstorm/page.tsx
+++ b/src/app/brainstorm/page.tsx
@@ -3,16 +3,31 @@
 import { useState } from "react";
 import { useIdeas } from "@/hooks/useIdeas";
 import { useIdeaLinks } from "@/hooks/useIdeaLinks";
+import { useTasks } from "@/hooks/useTasks";
+import { usePromoteIdea } from "@/hooks/usePromoteIdea";
 import { AppShell } from "@/components/AppShell";
 import { IdeaTree } from "@/components/brainstorm/IdeaTree";
 import { GraphView } from "@/components/brainstorm/GraphView";
+import { ConflictDialog } from "@/components/brainstorm/ConflictDialog";
+import { TimeBucket } from "@/lib/types";
 
 export default function BrainstormPage() {
   const ideasHook = useIdeas();
   const linksHook = useIdeaLinks();
+  const tasksHook = useTasks();
+  const { promote, conflictState, resolveConflict, dismissConflict } = usePromoteIdea(
+    tasksHook.activeTasksByIdeaId,
+    tasksHook.createTask,
+    tasksHook.updateTask
+  );
   const [viewMode, setViewMode] = useState<"tree" | "graph">("tree");
 
   const hasLinks = linksHook.links.length > 0;
+
+  const handlePromote = (ideaId: string, bucket: TimeBucket) => {
+    const idea = ideasHook.ideas.find((i) => i.id === ideaId);
+    if (idea) promote(idea, bucket);
+  };
 
   if (ideasHook.loading) {
     return (
@@ -58,6 +73,7 @@ export default function BrainstormPage() {
           tree={ideasHook.tree}
           ideas={ideasHook.ideas}
           links={linksHook.links}
+          activeTasksByIdeaId={tasksHook.activeTasksByIdeaId}
           createIdea={ideasHook.createIdea}
           updateIdea={ideasHook.updateIdea}
           deleteIdea={ideasHook.deleteIdea}
@@ -67,6 +83,7 @@ export default function BrainstormPage() {
           collapseAll={ideasHook.collapseAll}
           onCreateLink={linksHook.createLink}
           onDeleteLink={linksHook.deleteLink}
+          onPromote={handlePromote}
         />
       ) : (
         <GraphView
@@ -75,6 +92,14 @@ export default function BrainstormPage() {
           onNodeDoubleClick={(ideaId) => {
             setViewMode("tree");
           }}
+        />
+      )}
+      {conflictState && (
+        <ConflictDialog
+          existingTask={conflictState.existingTask}
+          targetBucket={conflictState.targetBucket}
+          onMove={() => resolveConflict("move")}
+          onCancel={dismissConflict}
         />
       )}
     </AppShell>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -12,7 +12,7 @@ interface AppShellProps {
   title: string;
   headerActions?: ReactNode;
   fullWidth?: boolean;
-  onAdd?: (title: string, bucket: TimeBucket, category: BalanceCategory) => Promise<void>;
+  onAdd?: (title: string, bucket: TimeBucket, category: BalanceCategory) => Promise<unknown>;
 }
 
 export function AppShell({ children, title, headerActions, fullWidth, onAdd }: AppShellProps) {

--- a/src/components/QuickAddButton.tsx
+++ b/src/components/QuickAddButton.tsx
@@ -8,7 +8,7 @@ interface QuickAddButtonProps {
     title: string,
     bucket: TimeBucket,
     category: BalanceCategory
-  ) => Promise<void>;
+  ) => Promise<unknown>;
 }
 
 export function QuickAddButton({ onAdd }: QuickAddButtonProps) {

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -141,6 +141,16 @@ export function TaskCard({ task, onComplete, onUpdate, onDelete }: TaskCardProps
               {task.balance_category}
             </span>
           </div>
+          {task.idea_id && (
+            <a
+              href={`/brainstorm?highlight=${task.idea_id}`}
+              className="inline-flex items-center gap-1 text-xs text-purple-500 hover:text-purple-700 mt-1"
+              title="Ver idea en brainstorm"
+            >
+              <span className="text-[10px]">🧠</span>
+              <span>Idea</span>
+            </a>
+          )}
         </div>
       </div>
       {showDatePicker && (

--- a/src/components/brainstorm/ConflictDialog.tsx
+++ b/src/components/brainstorm/ConflictDialog.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Task, TimeBucket } from "@/lib/types";
+
+const BUCKET_LABELS: Record<TimeBucket, string> = {
+  today: "Hoy",
+  tomorrow: "Mañana",
+  next_week: "Semana",
+  backlog: "Backlog",
+};
+
+interface ConflictDialogProps {
+  existingTask: Task;
+  targetBucket: TimeBucket;
+  onMove: () => void;
+  onCancel: () => void;
+}
+
+export function ConflictDialog({
+  existingTask,
+  targetBucket,
+  onMove,
+  onCancel,
+}: ConflictDialogProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+      <div className="bg-white rounded-xl shadow-xl w-80 p-5 space-y-4">
+        <h3 className="text-sm font-semibold text-gray-900">
+          Esta idea ya tiene una tarea activa
+        </h3>
+        <p className="text-sm text-gray-600">
+          Asignada actualmente a:{" "}
+          <span className="font-medium text-gray-800">
+            {BUCKET_LABELS[existingTask.time_bucket]}
+          </span>
+        </p>
+        <div className="flex flex-col gap-2">
+          <button
+            onClick={onMove}
+            className="w-full px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700"
+          >
+            Mover a {BUCKET_LABELS[targetBucket]}
+          </button>
+          <button
+            onClick={onCancel}
+            className="w-full px-4 py-2 border border-gray-300 text-gray-700 text-sm rounded-lg hover:bg-gray-50"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/brainstorm/IdeaNode.tsx
+++ b/src/components/brainstorm/IdeaNode.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState, useRef, useEffect, KeyboardEvent } from "react";
-import { IdeaNode as IdeaNodeType, Idea, IdeaLink, IdeaType, LifeArea, LinkType } from "@/lib/types";
+import { IdeaNode as IdeaNodeType, Idea, IdeaLink, IdeaType, LifeArea, LinkType, Task, TimeBucket } from "@/lib/types";
 import { TypePicker } from "./TypePicker";
 import { AreaPicker } from "./AreaPicker";
 import { LinkPanel } from "./LinkPanel";
+import { PromoteMenu } from "./PromoteMenu";
 
 interface IdeaNodeProps {
   node: IdeaNodeType;
@@ -23,6 +24,8 @@ interface IdeaNodeProps {
   links: IdeaLink[];
   onCreateLink: (sourceId: string, targetId: string, linkType: LinkType) => Promise<string>;
   onDeleteLink: (id: string) => Promise<void>;
+  activeTasksByIdeaId: Map<string, Task>;
+  onPromote: (ideaId: string, bucket: TimeBucket) => void;
 }
 
 const TYPE_COLORS: Record<IdeaType, string> = {
@@ -59,6 +62,8 @@ export function IdeaNode({
   links,
   onCreateLink,
   onDeleteLink,
+  activeTasksByIdeaId,
+  onPromote,
 }: IdeaNodeProps) {
   const isEditing = editingId === node.id;
   const [editText, setEditText] = useState(node.text);
@@ -66,8 +71,18 @@ export function IdeaNode({
   const [showAreaPicker, setShowAreaPicker] = useState(false);
   const [showLinkPanel, setShowLinkPanel] = useState(false);
   const [dragOver, setDragOver] = useState<"top" | "center" | "bottom" | null>(null);
+  const [showPromoteMenu, setShowPromoteMenu] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const rowRef = useRef<HTMLDivElement>(null);
+
+  const activeTask = activeTasksByIdeaId.get(node.id);
+
+  const BUCKET_CHIP_LABELS: Record<TimeBucket, string> = {
+    today: "Hoy",
+    tomorrow: "Mañana",
+    next_week: "Semana",
+    backlog: "Backlog",
+  };
 
   const linkCount = links.filter(
     (l) => l.source_id === node.id || l.target_id === node.id
@@ -278,6 +293,13 @@ export function IdeaNode({
           </span>
         )}
 
+        {/* Active task status chip */}
+        {activeTask && (
+          <span className="text-xs text-blue-600 bg-blue-50 px-1.5 py-0.5 rounded-full flex-shrink-0 border border-blue-200">
+            {BUCKET_CHIP_LABELS[activeTask.time_bucket]}
+          </span>
+        )}
+
         {/* Actions (visible on hover) */}
         <div className="relative flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
           <button
@@ -301,6 +323,30 @@ export function IdeaNode({
           >
             🔗
           </button>
+          {node.type === "task" && (
+            <div className="relative">
+              <button
+                onClick={() => setShowPromoteMenu(!showPromoteMenu)}
+                title="Promote to task"
+                className="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded text-xs"
+              >
+                ▶
+              </button>
+              {showPromoteMenu && (
+                <PromoteMenu
+                  hasActiveTask={!!activeTask}
+                  onSelect={(bucket) => {
+                    onPromote(node.id, bucket);
+                    setShowPromoteMenu(false);
+                  }}
+                  onViewInPlanner={activeTask ? () => {
+                    window.location.href = `/planner?highlight=${activeTask.id}`;
+                  } : undefined}
+                  onClose={() => setShowPromoteMenu(false)}
+                />
+              )}
+            </div>
+          )}
           <button
             onClick={() => deleteIdea(node.id)}
             title="Delete"
@@ -343,6 +389,8 @@ export function IdeaNode({
               links={links}
               onCreateLink={onCreateLink}
               onDeleteLink={onDeleteLink}
+              activeTasksByIdeaId={activeTasksByIdeaId}
+              onPromote={onPromote}
             />
           ))}
         </div>

--- a/src/components/brainstorm/IdeaTree.tsx
+++ b/src/components/brainstorm/IdeaTree.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { IdeaNode as IdeaNodeType, Idea, IdeaLink, IdeaType, LifeArea, LinkType } from "@/lib/types";
+import { IdeaNode as IdeaNodeType, Idea, IdeaLink, IdeaType, LifeArea, LinkType, Task, TimeBucket } from "@/lib/types";
 import { IdeaNode } from "./IdeaNode";
 
 interface IdeaTreeProps {
   tree: IdeaNodeType[];
   ideas: Idea[];
   links: IdeaLink[];
+  activeTasksByIdeaId: Map<string, Task>;
   createIdea: (text: string, parentId?: string | null) => Promise<string>;
   updateIdea: (id: string, updates: Partial<Idea>) => Promise<void>;
   deleteIdea: (id: string) => Promise<void>;
@@ -17,12 +18,14 @@ interface IdeaTreeProps {
   collapseAll: () => void;
   onCreateLink: (sourceId: string, targetId: string, linkType: LinkType) => Promise<string>;
   onDeleteLink: (id: string) => Promise<void>;
+  onPromote: (ideaId: string, bucket: TimeBucket) => void;
 }
 
 export function IdeaTree({
   tree,
   ideas,
   links,
+  activeTasksByIdeaId,
   createIdea,
   updateIdea,
   deleteIdea,
@@ -32,6 +35,7 @@ export function IdeaTree({
   collapseAll,
   onCreateLink,
   onDeleteLink,
+  onPromote,
 }: IdeaTreeProps) {
   const [search, setSearch] = useState("");
   const [showType, setShowType] = useState(true);
@@ -129,6 +133,8 @@ export function IdeaTree({
               links={links}
               onCreateLink={onCreateLink}
               onDeleteLink={onDeleteLink}
+              activeTasksByIdeaId={activeTasksByIdeaId}
+              onPromote={onPromote}
             />
           ))}
         </div>

--- a/src/components/brainstorm/PromoteMenu.tsx
+++ b/src/components/brainstorm/PromoteMenu.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { TimeBucket } from "@/lib/types";
+
+interface PromoteMenuProps {
+  onSelect: (bucket: TimeBucket) => void;
+  onClose: () => void;
+  onViewInPlanner?: () => void;
+  hasActiveTask: boolean;
+}
+
+const BUCKET_OPTIONS: { value: TimeBucket; label: string }[] = [
+  { value: "today", label: "Hacer hoy" },
+  { value: "tomorrow", label: "Hacer mañana" },
+  { value: "next_week", label: "Agregar a la semana" },
+  { value: "backlog", label: "Agregar al backlog" },
+];
+
+export function PromoteMenu({ onSelect, onClose, onViewInPlanner, hasActiveTask }: PromoteMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute right-0 top-full mt-1 z-50 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-1"
+    >
+      {hasActiveTask && onViewInPlanner && (
+        <>
+          <button
+            onClick={onViewInPlanner}
+            className="w-full text-left px-3 py-2 text-sm text-indigo-600 hover:bg-indigo-50"
+          >
+            Ver en planner
+          </button>
+          <div className="border-t border-gray-100 my-1" />
+        </>
+      )}
+      {BUCKET_OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onSelect(opt.value)}
+          className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/usePromoteIdea.ts
+++ b/src/hooks/usePromoteIdea.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { Task, TimeBucket, Idea, LifeArea, BalanceCategory } from "@/lib/types";
+
+function areaToCategory(area: LifeArea | null): BalanceCategory {
+  return area === "work" ? "work" : "life";
+}
+
+interface PromoteResult {
+  status: "created" | "conflict";
+  task?: Task;
+  existingTask?: Task;
+}
+
+export function usePromoteIdea(
+  activeTasksByIdeaId: Map<string, Task>,
+  createTask: (
+    title: string,
+    timeBucket: TimeBucket,
+    balanceCategory: BalanceCategory,
+    ideaId: string | null
+  ) => Promise<Task | undefined>,
+  updateTask: (id: string, updates: Partial<Task>) => Promise<void>
+) {
+  const [conflictState, setConflictState] = useState<{
+    idea: Idea;
+    existingTask: Task;
+    targetBucket: TimeBucket;
+  } | null>(null);
+
+  const promote = async (
+    idea: Idea,
+    targetBucket: TimeBucket
+  ): Promise<PromoteResult> => {
+    const existing = activeTasksByIdeaId.get(idea.id);
+    if (existing) {
+      setConflictState({ idea, existingTask: existing, targetBucket });
+      return { status: "conflict", existingTask: existing };
+    }
+
+    const category = areaToCategory(idea.area);
+    const task = await createTask(idea.text, targetBucket, category, idea.id);
+    return { status: "created", task };
+  };
+
+  const resolveConflict = async (action: "move") => {
+    if (!conflictState) return;
+    const { existingTask, targetBucket } = conflictState;
+    if (action === "move") {
+      await updateTask(existingTask.id, { time_bucket: targetBucket });
+    }
+    setConflictState(null);
+  };
+
+  const dismissConflict = () => {
+    setConflictState(null);
+  };
+
+  return {
+    promote,
+    conflictState,
+    resolveConflict,
+    dismissConflict,
+  };
+}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "./useAuth";
@@ -29,7 +29,8 @@ export function useTasks() {
   const createTask = async (
     title: string,
     timeBucket: TimeBucket = "today",
-    balanceCategory: BalanceCategory = "work"
+    balanceCategory: BalanceCategory = "work",
+    ideaId: string | null = null
   ) => {
     if (!user) return;
     const now = new Date().toISOString();
@@ -41,12 +42,14 @@ export function useTasks() {
       status: "active",
       time_bucket: timeBucket,
       balance_category: balanceCategory,
+      idea_id: ideaId,
       created_at: now,
       completed_at: null,
       updated_at: now,
     };
     setTasks((prev) => [task, ...prev]);
     await supabase.from("tasks").insert(task);
+    return task;
   };
 
   const updateTask = async (id: string, updates: Partial<Task>) => {
@@ -75,10 +78,19 @@ export function useTasks() {
   const activeTasks = tasks.filter((t) => t.status === "active");
   const completedTasks = tasks.filter((t) => t.status === "done");
 
+  const activeTasksByIdeaId = useMemo(() => {
+    const map = new Map<string, Task>();
+    for (const t of activeTasks) {
+      if (t.idea_id) map.set(t.idea_id, t);
+    }
+    return map;
+  }, [activeTasks]);
+
   return {
     tasks,
     activeTasks,
     completedTasks,
+    activeTasksByIdeaId,
     loading,
     createTask,
     updateTask,

--- a/src/lib/powersync.ts
+++ b/src/lib/powersync.ts
@@ -14,6 +14,7 @@ export const TasksTable = new Table(
     status: column.text,
     time_bucket: column.text,
     balance_category: column.text,
+    idea_id: column.text,
     created_at: column.text,
     completed_at: column.text,
     updated_at: column.text,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,7 @@ export interface Task {
   status: TaskStatus;
   time_bucket: TimeBucket;
   balance_category: BalanceCategory;
+  idea_id: string | null;
   created_at: string;
   completed_at: string | null;
   updated_at: string;

--- a/supabase/migrations/20250525000002_add_idea_id_to_tasks.sql
+++ b/supabase/migrations/20250525000002_add_idea_id_to_tasks.sql
@@ -1,0 +1,11 @@
+-- Add idea_id to tasks for bidirectional idea-task linking
+alter table public.tasks
+  add column idea_id uuid references public.ideas(id) on delete set null;
+
+-- Fast lookup: idea → its tasks
+create index tasks_idea_id_idx on public.tasks(idea_id);
+
+-- Only one active task per idea at a time
+create unique index tasks_idea_id_active_uniq
+  on public.tasks(idea_id)
+  where status = 'active' and idea_id is not null;


### PR DESCRIPTION
## Summary

- Adds bidirectional link between brainstorm ideas and planner tasks via `idea_id` FK on `tasks` table
- New `usePromoteIdea` hook with conflict detection (only one active task per idea enforced at DB level)
- Brainstorm UI: promote button (▶) on ideas with type "task", context menu for bucket selection, blue status chip showing current assignment
- Conflict dialog when promoting an idea that already has an active task — options: move to new bucket or cancel
- Reverse link on TaskCard (🧠 Idea) navigating back to brainstorm

## Files Changed

**Data layer:**
- `supabase/migrations/20250525000002_add_idea_id_to_tasks.sql` — migration with partial unique index
- `src/lib/powersync.ts` — added `idea_id` to sync schema
- `src/lib/types.ts` — added `idea_id` to Task interface

**Hooks:**
- `src/hooks/useTasks.ts` — `activeTasksByIdeaId` map + `ideaId` param on `createTask`
- `src/hooks/usePromoteIdea.ts` — promotion logic with conflict state

**Components:**
- `src/components/brainstorm/PromoteMenu.tsx` — bucket selection dropdown
- `src/components/brainstorm/ConflictDialog.tsx` — conflict resolution modal
- `src/components/brainstorm/IdeaNode.tsx` — promote button + status chip
- `src/components/brainstorm/IdeaTree.tsx` — prop threading
- `src/components/TaskCard.tsx` — brain icon reverse link
- `src/app/brainstorm/page.tsx` — wiring hooks + dialog

## Test plan

- [ ] Run SQL migration against Supabase
- [ ] Update PowerSync sync rules to include `idea_id` column
- [ ] Create idea with type "task" → hover → see ▶ button
- [ ] Click ▶ → select bucket → verify task created in planner
- [ ] Verify blue chip shows on idea in brainstorm
- [ ] Promote same idea again → conflict dialog appears
- [ ] Click "Mover" → task bucket changes
- [ ] Click "Cancelar" → dialog dismisses, no change
- [ ] Complete task in planner → chip disappears in brainstorm
- [ ] Verify 🧠 icon on TaskCard links back to brainstorm
- [ ] Ideas without type "task" do NOT show promote button