### PR TITLE
Add inline child idea composer

### DIFF
--- a/src/app/brainstorm/page.tsx
+++ b/src/app/brainstorm/page.tsx
@@ -89,7 +89,7 @@ export default function BrainstormPage() {
         <GraphView
           ideas={ideasHook.ideas}
           links={linksHook.links}
-          onNodeDoubleClick={(ideaId) => {
+          onNodeDoubleClick={() => {
             setViewMode("tree");
           }}
         />

--- a/src/components/brainstorm/IdeaComposer.tsx
+++ b/src/components/brainstorm/IdeaComposer.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { KeyboardEvent, useState } from "react";
+
+interface IdeaComposerProps {
+  depth?: number;
+  placeholder: string;
+  onCreate: (text: string) => Promise<void>;
+  onDismiss?: () => void;
+}
+
+export function IdeaComposer({ depth = 0, placeholder, onCreate, onDismiss }: IdeaComposerProps) {
+  const [text, setText] = useState("");
+
+  const submit = async () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setText("");
+    await onCreate(trimmed);
+  };
+
+  const handleKeyDown = async (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      await submit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      if (text) {
+        setText("");
+      } else if (onDismiss) {
+        onDismiss();
+      }
+    }
+  };
+
+  return (
+    <div style={{ paddingLeft: depth > 0 ? 20 * depth : 0 }} onClick={(e) => e.stopPropagation()}>
+      <div className="flex items-center gap-1 py-1 px-1 rounded-md bg-indigo-50/40">
+        <span className="w-5 h-5 flex-shrink-0" />
+        <span className="w-[14px] flex-shrink-0 text-gray-300 text-sm select-none">+</span>
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="flex-1 text-sm px-2 py-0.5 border border-dashed border-indigo-200 rounded outline-none focus:border-indigo-500 focus:border-solid min-w-0 bg-white"
+          placeholder={placeholder}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/brainstorm/IdeaNode.tsx
+++ b/src/components/brainstorm/IdeaNode.tsx
@@ -6,6 +6,7 @@ import { TypePicker } from "./TypePicker";
 import { AreaPicker } from "./AreaPicker";
 import { LinkPanel } from "./LinkPanel";
 import { PromoteMenu } from "./PromoteMenu";
+import { IdeaComposer } from "./IdeaComposer";
 
 interface IdeaNodeProps {
   node: IdeaNodeType;
@@ -15,7 +16,9 @@ interface IdeaNodeProps {
   search: string;
   editingId: string | null;
   setEditingId: (id: string | null) => void;
-  createIdea: (text: string, parentId?: string | null) => Promise<string>;
+  selectedId: string | null;
+  setSelectedId: (id: string | null) => void;
+  createIdea: (text: string, parentId?: string | null, position?: "top" | "bottom") => Promise<string>;
   updateIdea: (id: string, updates: Partial<Idea>) => Promise<void>;
   deleteIdea: (id: string) => Promise<void>;
   moveIdea: (id: string, newParentId: string | null, newSortOrder: number) => Promise<void>;
@@ -53,6 +56,8 @@ export function IdeaNode({
   search,
   editingId,
   setEditingId,
+  selectedId,
+  setSelectedId,
   createIdea,
   updateIdea,
   deleteIdea,
@@ -66,6 +71,7 @@ export function IdeaNode({
   onPromote,
 }: IdeaNodeProps) {
   const isEditing = editingId === node.id;
+  const isSelected = selectedId === node.id;
   const [editText, setEditText] = useState(node.text);
   const [showTypePicker, setShowTypePicker] = useState(false);
   const [showAreaPicker, setShowAreaPicker] = useState(false);
@@ -95,13 +101,10 @@ export function IdeaNode({
     }
   }, [isEditing]);
 
-  useEffect(() => {
-    setEditText(node.text);
-  }, [node.text]);
-
   const hasChildren = node.children.length > 0;
 
   const handleStartEdit = () => {
+    setSelectedId(node.id);
     setEditText(node.text);
     setEditingId(node.id);
   };
@@ -132,19 +135,36 @@ export function IdeaNode({
     } else if (e.key === "Tab") {
       e.preventDefault();
       handleConfirmEdit();
-      const childId = await createIdea("", node.id);
-      if (childId) setEditingId(childId);
+      const childId = await createIdea("", node.id, "top");
+      if (node.collapsed) toggleCollapse(node.id);
+      if (childId) {
+        setSelectedId(childId);
+        setEditingId(childId);
+      }
     }
   };
 
   const handleAddChild = async () => {
-    const childId = await createIdea("", node.id);
-    if (childId) setEditingId(childId);
+    const childId = await createIdea("", node.id, "top");
+    if (node.collapsed) toggleCollapse(node.id);
+    if (childId) {
+      setSelectedId(childId);
+      setEditingId(childId);
+    }
   };
 
   const handleAddSibling = async () => {
-    const siblingId = await createIdea("", node.parent_id);
-    if (siblingId) setEditingId(siblingId);
+    const siblingId = await createIdea("", node.parent_id, "top");
+    if (siblingId) {
+      setSelectedId(siblingId);
+      setEditingId(siblingId);
+    }
+  };
+
+  const handleCreateChild = async (text: string) => {
+    const childId = await createIdea(text, node.id, "top");
+    if (node.collapsed) toggleCollapse(node.id);
+    if (childId) setSelectedId(childId);
   };
 
   const handleDragStart = (e: React.DragEvent) => {
@@ -194,8 +214,10 @@ export function IdeaNode({
         className={`group flex items-center gap-1 py-1 px-1 rounded-md ${
           dragOver === "top" ? "border-t-2 border-indigo-400" :
           dragOver === "bottom" ? "border-b-2 border-indigo-400" :
-          dragOver === "center" ? "bg-indigo-50" : ""
+          dragOver === "center" ? "bg-indigo-50" :
+          isSelected ? "bg-indigo-50/60" : ""
         }`}
+        onClick={(e) => { e.stopPropagation(); setSelectedId(isSelected ? null : node.id); }}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
@@ -367,6 +389,15 @@ export function IdeaNode({
         </div>
       </div>
 
+      {isSelected && !search && !node.collapsed && (
+        <IdeaComposer
+          depth={depth + 1}
+          placeholder="Add child idea..."
+          onCreate={handleCreateChild}
+          onDismiss={() => setSelectedId(null)}
+        />
+      )}
+
       {/* Children */}
       {hasChildren && !node.collapsed && (
         <div>
@@ -380,6 +411,8 @@ export function IdeaNode({
               search={search}
               editingId={editingId}
               setEditingId={setEditingId}
+              selectedId={selectedId}
+              setSelectedId={setSelectedId}
               createIdea={createIdea}
               updateIdea={updateIdea}
               deleteIdea={deleteIdea}

--- a/src/components/brainstorm/IdeaTree.tsx
+++ b/src/components/brainstorm/IdeaTree.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { IdeaNode as IdeaNodeType, Idea, IdeaLink, IdeaType, LifeArea, LinkType, Task, TimeBucket } from "@/lib/types";
+import { IdeaNode as IdeaNodeType, Idea, IdeaLink, LinkType, Task, TimeBucket } from "@/lib/types";
 import { IdeaNode } from "./IdeaNode";
 
 interface IdeaTreeProps {
@@ -9,7 +9,7 @@ interface IdeaTreeProps {
   ideas: Idea[];
   links: IdeaLink[];
   activeTasksByIdeaId: Map<string, Task>;
-  createIdea: (text: string, parentId?: string | null) => Promise<string>;
+  createIdea: (text: string, parentId?: string | null, position?: "top" | "bottom") => Promise<string>;
   updateIdea: (id: string, updates: Partial<Idea>) => Promise<void>;
   deleteIdea: (id: string) => Promise<void>;
   moveIdea: (id: string, newParentId: string | null, newSortOrder: number) => Promise<void>;
@@ -41,10 +41,14 @@ export function IdeaTree({
   const [showType, setShowType] = useState(true);
   const [showArea, setShowArea] = useState(true);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const handleAddRoot = async () => {
-    const id = await createIdea("");
-    if (id) setEditingId(id);
+    const id = await createIdea("", null, "top");
+    if (id) {
+      setSelectedId(id);
+      setEditingId(id);
+    }
   };
 
   const matchesSearch = (node: IdeaNodeType): boolean => {
@@ -57,7 +61,7 @@ export function IdeaTree({
   const filteredTree = search ? tree.filter(matchesSearch) : tree;
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" onClick={() => setSelectedId(null)}>
       <div className="flex flex-wrap items-center gap-2">
         <button
           onClick={handleAddRoot}
@@ -108,6 +112,7 @@ export function IdeaTree({
         </div>
       </div>
 
+
       {filteredTree.length === 0 ? (
         <p className="text-sm text-gray-400 italic py-4">
           {search ? "No matching ideas" : "No ideas yet. Click \"+ New idea\" to start."}
@@ -124,6 +129,8 @@ export function IdeaTree({
               search={search}
               editingId={editingId}
               setEditingId={setEditingId}
+              selectedId={selectedId}
+              setSelectedId={setSelectedId}
               createIdea={createIdea}
               updateIdea={updateIdea}
               deleteIdea={deleteIdea}

--- a/src/hooks/useIdeaLinks.ts
+++ b/src/hooks/useIdeaLinks.ts
@@ -22,8 +22,25 @@ export function useIdeaLinks() {
   }, [user]);
 
   useEffect(() => {
-    fetchLinks();
-  }, [fetchLinks]);
+    if (!user) return;
+    let cancelled = false;
+
+    const loadLinks = async () => {
+      const { data } = await supabase
+        .from("idea_links")
+        .select("*")
+        .eq("user_id", user.id);
+      if (cancelled) return;
+      if (data) setLinks(data as IdeaLink[]);
+      setLoading(false);
+    };
+
+    void loadLinks();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
 
   const createLink = async (
     sourceId: string,

--- a/src/hooks/useIdeas.ts
+++ b/src/hooks/useIdeas.ts
@@ -4,12 +4,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "./useAuth";
-import { Idea, IdeaNode, IdeaType, LifeArea } from "@/lib/types";
+import { Idea, IdeaNode } from "@/lib/types";
 
 const STORAGE_KEY = "brainstorm-tree-overrides";
 const DEFAULT_EXPAND_DEPTH = 1;
 
 type OverrideState = "expanded" | "collapsed";
+export type CreateIdeaPosition = "top" | "bottom";
 
 function loadOverrides(): Map<string, OverrideState> {
   try {
@@ -114,15 +115,42 @@ export function useIdeas() {
   }, [user]);
 
   useEffect(() => {
-    fetchIdeas();
-  }, [fetchIdeas]);
+    if (!user) return;
+    let cancelled = false;
 
-  const createIdea = async (text: string, parentId: string | null = null): Promise<string> => {
+    const loadIdeas = async () => {
+      const { data } = await supabase
+        .from("ideas")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("sort_order", { ascending: true });
+      if (cancelled) return;
+      if (data) setIdeas(data as Idea[]);
+      setLoading(false);
+    };
+
+    void loadIdeas();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const createIdea = async (
+    text: string,
+    parentId: string | null = null,
+    position: CreateIdeaPosition = "bottom"
+  ): Promise<string> => {
     if (!user) return "";
     const siblings = ideas.filter((i) => i.parent_id === parentId);
     const maxOrder = siblings.length > 0 ? Math.max(...siblings.map((s) => s.sort_order)) : -1;
     const now = new Date().toISOString();
     const id = uuidv4();
+    const sortOrder = position === "top" ? 0 : maxOrder + 1;
+    const reorderedSiblings =
+      position === "top"
+        ? siblings.map((s) => ({ ...s, sort_order: s.sort_order + 1 }))
+        : [];
     const idea: Idea = {
       id,
       user_id: user.id,
@@ -133,12 +161,22 @@ export function useIdeas() {
       effort: null,
       impact: null,
       urgency: null,
-      sort_order: maxOrder + 1,
+      sort_order: sortOrder,
       created_at: now,
       updated_at: now,
     };
-    setIdeas((prev) => [...prev, idea]);
+    setIdeas((prev) =>
+      prev
+        .map((i) => reorderedSiblings.find((s) => s.id === i.id) ?? i)
+        .concat(idea)
+    );
     await supabase.from("ideas").insert(idea);
+    for (const sibling of reorderedSiblings) {
+      await supabase
+        .from("ideas")
+        .update({ sort_order: sibling.sort_order })
+        .eq("id", sibling.id);
+    }
     return id;
   };
 

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -23,8 +23,26 @@ export function useTasks() {
   }, [user]);
 
   useEffect(() => {
-    fetchTasks();
-  }, [fetchTasks]);
+    if (!user) return;
+    let cancelled = false;
+
+    const loadTasks = async () => {
+      const { data } = await supabase
+        .from("tasks")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("created_at", { ascending: false });
+      if (cancelled) return;
+      if (data) setTasks(data as Task[]);
+      setLoading(false);
+    };
+
+    void loadTasks();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
 
   const createTask = async (
     title: string,


### PR DESCRIPTION
## Summary
- add an inline composer that appears for the selected brainstorm idea
- support inserting new ideas at the top of a sibling list
- avoid stale async state updates when loading ideas, links, and tasks

## Test
- pnpm lint