### PR TITLE
feat: dark mode with automatic system preference detection

### DIFF
--- a/src/app/backup/page.tsx
+++ b/src/app/backup/page.tsx
@@ -101,14 +101,14 @@ export default function BackupPage() {
           transition={{ duration: 0.3 }}
           className="glass-card rounded-[20px] p-5"
         >
-          <h2 className="text-sm font-bold text-gray-800 mb-1">Export</h2>
-          <p className="text-xs text-gray-500 mb-4">
+          <h2 className="text-sm font-bold text-gray-800 dark:text-gray-200 mb-1">Export</h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
             Download a JSON snapshot of all your ideas and links.
           </p>
           <button
             onClick={handleExport}
             disabled={exporting}
-            className="px-4 py-2 bg-white/80 text-sm font-medium text-gray-700 rounded-xl border border-black/10 hover:bg-white hover:shadow-sm transition-all disabled:opacity-50"
+            className="px-4 py-2 bg-white/80 dark:bg-gray-700/80 text-sm font-medium text-gray-700 dark:text-gray-300 rounded-xl border border-black/10 dark:border-white/10 hover:bg-white dark:hover:bg-gray-700 hover:shadow-sm transition-all disabled:opacity-50"
           >
             {exporting ? "Exporting..." : "Download backup"}
           </button>
@@ -121,11 +121,11 @@ export default function BackupPage() {
           transition={{ duration: 0.3, delay: 0.05 }}
           className="glass-card rounded-[20px] p-5"
         >
-          <h2 className="text-sm font-bold text-gray-800 mb-1">Import</h2>
-          <p className="text-xs text-gray-500 mb-4">
+          <h2 className="text-sm font-bold text-gray-800 dark:text-gray-200 mb-1">Import</h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
             Restore from a previously exported JSON file. Existing data is merged (not overwritten).
           </p>
-          <label className="inline-block px-4 py-2 bg-white/80 text-sm font-medium text-gray-700 rounded-xl border border-black/10 hover:bg-white hover:shadow-sm cursor-pointer transition-all">
+          <label className="inline-block px-4 py-2 bg-white/80 dark:bg-gray-700/80 text-sm font-medium text-gray-700 dark:text-gray-300 rounded-xl border border-black/10 dark:border-white/10 hover:bg-white dark:hover:bg-gray-700 hover:shadow-sm cursor-pointer transition-all">
             {importing ? "Importing..." : "Choose file..."}
             <input
               type="file"
@@ -148,8 +148,8 @@ export default function BackupPage() {
             animate={{ opacity: 1, y: 0 }}
             className={`rounded-[16px] px-4 py-3 text-sm ${
               message.type === "success"
-                ? "glass-card border-emerald-200/50 text-emerald-700"
-                : "glass-card border-red-200/50 text-red-600"
+                ? "glass-card border-emerald-200/50 dark:border-emerald-700/30 text-emerald-700 dark:text-emerald-400"
+                : "glass-card border-red-200/50 dark:border-red-700/30 text-red-600 dark:text-red-400"
             }`}
           >
             {message.text}

--- a/src/app/brainstorm/page.tsx
+++ b/src/app/brainstorm/page.tsx
@@ -182,7 +182,7 @@ export default function BrainstormPage() {
   if (ideasHook.loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-pulse text-gray-400">Loading...</div>
+        <div className="animate-pulse text-gray-400 dark:text-gray-500">Loading...</div>
       </div>
     );
   }
@@ -218,20 +218,20 @@ export default function BrainstormPage() {
         <motion.div
           initial={{ opacity: 0, y: -4 }}
           animate={{ opacity: 1, y: 0 }}
-          className="mb-3 flex items-center justify-between gap-3 rounded-[16px] glass-card border-amber-200/40 px-4 py-2.5"
+          className="mb-3 flex items-center justify-between gap-3 rounded-[16px] glass-card border-amber-200/40 dark:border-amber-700/30 px-4 py-2.5"
         >
-          <span className="text-sm text-amber-800 font-medium">{undoAction.label}</span>
+          <span className="text-sm text-amber-800 dark:text-amber-300 font-medium">{undoAction.label}</span>
           <div className="flex items-center gap-1.5">
             <button
               onClick={handleUndo}
-              className="text-xs font-semibold text-amber-700 hover:bg-amber-100/60 rounded-lg px-2.5 py-1 transition-colors"
+              className="text-xs font-semibold text-amber-700 dark:text-amber-400 hover:bg-amber-100/60 dark:hover:bg-amber-900/20 rounded-lg px-2.5 py-1 transition-colors"
             >
               Undo
             </button>
             <button
               onClick={clearUndo}
               aria-label="Dismiss undo"
-              className="w-7 h-7 flex items-center justify-center rounded-lg text-amber-600 hover:bg-amber-100/60 transition-colors"
+              className="w-7 h-7 flex items-center justify-center rounded-lg text-amber-600 dark:text-amber-400 hover:bg-amber-100/60 dark:hover:bg-amber-900/20 transition-colors"
             >
               <span className="text-sm">×</span>
             </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,10 +5,105 @@
   --font-geist-sans: "Plus Jakarta Sans", system-ui, sans-serif;
 }
 
+:root {
+  color-scheme: light dark;
+  --bg-page: #f8f7fc;
+  --bg-glass: rgba(255, 255, 255, 0.7);
+  --bg-glass-strong: rgba(255, 255, 255, 0.82);
+  --bg-glass-sidebar: rgba(255, 255, 255, 0.72);
+  --bg-glass-today: rgba(255, 255, 255, 0.82);
+  --border-glass: rgba(255, 255, 255, 0.2);
+  --border-glass-strong: rgba(255, 255, 255, 0.25);
+  --border-today: rgba(139, 92, 246, 0.15);
+  --shadow-glass: 0 8px 32px rgba(0, 0, 0, 0.06);
+  --shadow-glass-strong: 0 8px 32px rgba(0, 0, 0, 0.08);
+  --shadow-glass-sidebar: 4px 0 32px rgba(0, 0, 0, 0.04);
+  --text-primary: #1f2937;
+  --text-secondary: #4b5563;
+  --text-tertiary: #6b7280;
+  --text-muted: #9ca3af;
+  --text-subtle: #d1d5db;
+  --row-hover: rgba(0, 0, 0, 0.03);
+  --focus-button-bg: rgba(255, 255, 255, 0.7);
+  --focus-button-border: rgba(0, 0, 0, 0.08);
+  --focus-button-text: #374151;
+  --btn-default-bg: rgba(0, 0, 0, 0.04);
+  --btn-default-text: #9ca3af;
+  --border-default: rgba(0, 0, 0, 0.1);
+  --invert-divider: rgba(0, 0, 0, 0.06);
+  --scrollbar-thumb: rgba(0, 0, 0, 0.1);
+  --mesh-violet: rgba(139, 92, 246, 0.25);
+  --mesh-sky: rgba(56, 189, 248, 0.2);
+  --mesh-indigo: rgba(79, 70, 229, 0.2);
+  --ring-bg: rgba(0, 0, 0, 0.06);
+  --badge-bg: rgba(0, 0, 0, 0.04);
+
+  --area-life-bg: rgba(139, 92, 246, 0.12);
+  --area-life-text: #7c3aed;
+  --area-work-bg: rgba(59, 130, 246, 0.12);
+  --area-work-text: #2563eb;
+  --area-finances-bg: rgba(16, 185, 129, 0.12);
+  --area-finances-text: #059669;
+  --area-relationships-bg: rgba(244, 63, 94, 0.12);
+  --area-relationships-text: #e11d48;
+  --area-health-bg: rgba(239, 68, 68, 0.12);
+  --area-health-text: #dc2626;
+  --area-growth-bg: rgba(245, 158, 11, 0.12);
+  --area-growth-text: #d97706;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-page: #0b0b14;
+    --bg-glass: rgba(30, 30, 48, 0.55);
+    --bg-glass-strong: rgba(30, 30, 48, 0.7);
+    --bg-glass-sidebar: rgba(20, 20, 35, 0.65);
+    --bg-glass-today: rgba(30, 30, 48, 0.7);
+    --border-glass: rgba(255, 255, 255, 0.06);
+    --border-glass-strong: rgba(255, 255, 255, 0.08);
+    --border-today: rgba(139, 92, 246, 0.25);
+    --shadow-glass: 0 8px 32px rgba(0, 0, 0, 0.3);
+    --shadow-glass-strong: 0 8px 32px rgba(0, 0, 0, 0.4);
+    --shadow-glass-sidebar: 4px 0 32px rgba(0, 0, 0, 0.3);
+    --text-primary: #e5e7eb;
+    --text-secondary: #d1d5db;
+    --text-tertiary: #9ca3af;
+    --text-muted: #6b7280;
+    --text-subtle: #4b5563;
+    --row-hover: rgba(255, 255, 255, 0.04);
+    --focus-button-bg: rgba(255, 255, 255, 0.06);
+    --focus-button-border: rgba(255, 255, 255, 0.1);
+    --focus-button-text: #d1d5db;
+    --btn-default-bg: rgba(255, 255, 255, 0.06);
+    --btn-default-text: #6b7280;
+    --border-default: rgba(255, 255, 255, 0.08);
+    --invert-divider: rgba(255, 255, 255, 0.06);
+    --scrollbar-thumb: rgba(255, 255, 255, 0.12);
+    --mesh-violet: rgba(139, 92, 246, 0.12);
+    --mesh-sky: rgba(56, 189, 248, 0.08);
+    --mesh-indigo: rgba(79, 70, 229, 0.1);
+    --ring-bg: rgba(255, 255, 255, 0.08);
+    --badge-bg: rgba(255, 255, 255, 0.06);
+
+    --area-life-bg: rgba(139, 92, 246, 0.2);
+    --area-life-text: #a78bfa;
+    --area-work-bg: rgba(59, 130, 246, 0.2);
+    --area-work-text: #93c5fd;
+    --area-finances-bg: rgba(16, 185, 129, 0.2);
+    --area-finances-text: #6ee7b7;
+    --area-relationships-bg: rgba(244, 63, 94, 0.2);
+    --area-relationships-text: #fda4af;
+    --area-health-bg: rgba(239, 68, 68, 0.2);
+    --area-health-text: #fca5a5;
+    --area-growth-bg: rgba(245, 158, 11, 0.2);
+    --area-growth-text: #fde68a;
+  }
+}
+
 @layer base {
   * {
     scrollbar-width: thin;
-    scrollbar-color: rgba(0, 0, 0, 0.1) transparent;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
   }
 
   *::-webkit-scrollbar {
@@ -21,13 +116,13 @@
   }
 
   *::-webkit-scrollbar-thumb {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--scrollbar-thumb);
     border-radius: 3px;
   }
 }
 
 body {
-  background: #f8f7fc;
+  background: var(--bg-page);
   font-family: "Plus Jakarta Sans", system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
@@ -53,7 +148,7 @@ body {
 .background-mesh::before {
   width: 600px;
   height: 600px;
-  background: radial-gradient(circle, rgba(139, 92, 246, 0.25) 0%, transparent 70%);
+  background: radial-gradient(circle, var(--mesh-violet) 0%, transparent 70%);
   top: -200px;
   left: -100px;
 }
@@ -61,7 +156,7 @@ body {
 .background-mesh::after {
   width: 500px;
   height: 500px;
-  background: radial-gradient(circle, rgba(56, 189, 248, 0.2) 0%, transparent 70%);
+  background: radial-gradient(circle, var(--mesh-sky) 0%, transparent 70%);
   bottom: -150px;
   right: -100px;
 }
@@ -73,7 +168,7 @@ body {
   opacity: 0.2;
   width: 400px;
   height: 400px;
-  background: radial-gradient(circle, rgba(79, 70, 229, 0.2) 0%, transparent 70%);
+  background: radial-gradient(circle, var(--mesh-indigo) 0%, transparent 70%);
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
@@ -81,36 +176,36 @@ body {
 
 /* Glass surface utility */
 .glass-card {
-  background: rgba(255, 255, 255, 0.7);
+  background: var(--bg-glass);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.06);
+  border: 1px solid var(--border-glass);
+  box-shadow: var(--shadow-glass);
 }
 
 .glass-card-strong {
-  background: rgba(255, 255, 255, 0.82);
+  background: var(--bg-glass-strong);
   backdrop-filter: blur(24px) saturate(180%);
   -webkit-backdrop-filter: blur(24px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--border-glass-strong);
+  box-shadow: var(--shadow-glass-strong);
 }
 
 .glass-sidebar {
-  background: rgba(255, 255, 255, 0.72);
+  background: var(--bg-glass-sidebar);
   backdrop-filter: blur(24px) saturate(180%);
   -webkit-backdrop-filter: blur(24px) saturate(180%);
-  border-right: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 4px 0 32px rgba(0, 0, 0, 0.04);
+  border-right: 1px solid var(--border-glass);
+  box-shadow: var(--shadow-glass-sidebar);
 }
 
 /* Today card highlight */
 .glass-card-today {
-  background: rgba(255, 255, 255, 0.82);
+  background: var(--bg-glass-today);
   backdrop-filter: blur(24px) saturate(180%);
   -webkit-backdrop-filter: blur(24px) saturate(180%);
-  border: 1px solid rgba(139, 92, 246, 0.15);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(139, 92, 246, 0.08);
+  border: 1px solid var(--border-today);
+  box-shadow: var(--shadow-glass-strong), 0 0 0 1px var(--border-today);
 }
 
 /* No scrollbar utility */
@@ -124,9 +219,9 @@ body {
 
 /* Focus button */
 .focus-button {
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  color: #374151;
+  background: var(--focus-button-bg);
+  border: 1px solid var(--focus-button-border);
+  color: var(--focus-button-text);
   border-radius: 9999px;
   font-size: 11px;
   padding: 4px 14px;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,14 +25,12 @@ const MODE_META: Record<RingMode, { desc: string; statLabel: string; statSub: st
 
 const GROUP_ORDER: ScheduleGroup[] = ["Today", "Tomorrow", "This week", "Later", "Unscheduled"];
 
-const AREA_COLORS: Record<LifeArea, { bg: string; text: string }> = {
-  work: { bg: "rgba(59, 130, 246, 0.1)", text: "#2563eb" },
-  health: { bg: "rgba(239, 68, 68, 0.1)", text: "#dc2626" },
-  relationships: { bg: "rgba(244, 63, 94, 0.1)", text: "#e11d48" },
-  growth: { bg: "rgba(245, 158, 11, 0.1)", text: "#d97706" },
-  finances: { bg: "rgba(16, 185, 129, 0.1)", text: "#059669" },
-  life: { bg: "rgba(139, 92, 246, 0.1)", text: "#7c3aed" },
-};
+function areaStyle(area: LifeArea): React.CSSProperties {
+  return {
+    background: `var(--area-${area}-bg)`,
+    color: `var(--area-${area}-text)`,
+  };
+}
 
 function areaCounts(items: Idea[]): Record<LifeArea, number> {
   const counts: Record<LifeArea, number> = { work: 0, health: 0, relationships: 0, growth: 0, finances: 0, life: 0 };
@@ -102,7 +100,7 @@ export default function TodayPage() {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-pulse text-gray-400">Loading...</div>
+        <div className="animate-pulse text-gray-400 dark:text-gray-500">Loading...</div>
       </div>
     );
   }
@@ -111,15 +109,15 @@ export default function TodayPage() {
     <AppShell title="Today" onAdd={handleAdd}>
       <div className="space-y-5">
         {/* Mode toggle */}
-        <div className="flex gap-0.5 bg-white/60 backdrop-blur-sm rounded-xl p-1 border border-white/20 shadow-sm">
+        <div className="flex gap-0.5 bg-white/60 dark:bg-white/5 backdrop-blur-sm rounded-xl p-1 border border-white/20 dark:border-white/5 shadow-sm">
           {MODES.map(({ key, label }) => (
             <button
               key={key}
               onClick={() => setMode(key)}
               className={`flex-1 px-2 py-1.5 text-xs rounded-lg transition-all ${
                 mode === key
-                  ? "bg-white text-gray-800 font-medium shadow-sm border border-gray-200/60"
-                  : "text-gray-400 hover:text-gray-600"
+                  ? "bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200 font-medium shadow-sm border border-gray-200/60 dark:border-gray-600"
+                  : "text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
               }`}
             >
               {label}
@@ -147,8 +145,8 @@ export default function TodayPage() {
               transition={{ duration: 0.3 }}
             >
               <div className="flex items-center gap-2 mb-2.5">
-                <h2 className="text-xs font-semibold text-gray-600">{group}</h2>
-                <span className="text-[10px] font-semibold text-violet-600 bg-violet-100/60 px-2 py-0.5 rounded-full">
+                <h2 className="text-xs font-semibold text-gray-600 dark:text-gray-400">{group}</h2>
+                <span className="text-[10px] font-semibold text-violet-600 dark:text-violet-400 bg-violet-100/60 dark:bg-violet-500/20 px-2 py-0.5 rounded-full">
                   {items.length}
                 </span>
               </div>
@@ -160,19 +158,16 @@ export default function TodayPage() {
                   >
                     <button
                       onClick={() => markDone(idea.id)}
-                      className="w-[18px] h-[18px] rounded-full border-2 border-gray-300 hover:border-violet-500 flex-shrink-0 transition-colors"
+                      className="w-[18px] h-[18px] rounded-full border-2 border-gray-300 dark:border-gray-600 hover:border-violet-500 flex-shrink-0 transition-colors"
                       aria-label="Complete task"
                     />
-                    <span className="text-sm text-gray-800 truncate flex-1" style={{ fontWeight: 450 }}>
+                    <span className="text-sm text-gray-800 dark:text-gray-200 truncate flex-1" style={{ fontWeight: 450 }}>
                       {idea.text}
                     </span>
                     {idea.area && (
                       <span
                         className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
-                        style={{
-                          background: AREA_COLORS[idea.area].bg,
-                          color: AREA_COLORS[idea.area].text,
-                        }}
+                        style={areaStyle(idea.area)}
                       >
                         {idea.area}
                       </span>
@@ -180,7 +175,7 @@ export default function TodayPage() {
                     {group !== "Today" && (
                       <button
                         onClick={() => scheduleIdea(idea.id, today)}
-                        className="text-[11px] text-violet-600 hover:text-violet-800 font-medium flex-shrink-0 transition-colors"
+                        className="text-[11px] text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-300 font-medium flex-shrink-0 transition-colors"
                         title="Move to today"
                       >
                         → Today
@@ -199,11 +194,11 @@ export default function TodayPage() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3, delay: 0.1 }}
         >
-          <h2 className="text-xs font-semibold text-gray-500 mb-2.5">
+          <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-2.5">
             Completed today ({doneToday.length})
           </h2>
           {doneToday.length === 0 ? (
-            <p className="text-xs text-gray-400 py-2 italic">No tasks completed yet today</p>
+            <p className="text-xs text-gray-400 dark:text-gray-500 py-2 italic">No tasks completed yet today</p>
           ) : (
             <div className="space-y-1.5">
               {doneToday.map((idea) => (
@@ -218,16 +213,13 @@ export default function TodayPage() {
                   >
                     <Check size={10} strokeWidth={3} className="text-white" />
                   </button>
-                  <span className="text-sm text-gray-400 line-through truncate flex-1" style={{ opacity: 0.6 }}>
+                  <span className="text-sm text-gray-400 dark:text-gray-500 line-through truncate flex-1" style={{ opacity: 0.6 }}>
                     {idea.text}
                   </span>
                   {idea.area && (
                     <span
                       className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
-                      style={{
-                        background: AREA_COLORS[idea.area].bg,
-                        color: AREA_COLORS[idea.area].text,
-                      }}
+                      style={areaStyle(idea.area)}
                     >
                       {idea.area}
                     </span>

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -14,15 +14,6 @@ import {
   isPast,
 } from "@/lib/dateUtils";
 
-const AREA_COLORS: Record<LifeArea, { bg: string; text: string }> = {
-  work: { bg: "rgba(59, 130, 246, 0.1)", text: "#2563eb" },
-  health: { bg: "rgba(239, 68, 68, 0.1)", text: "#dc2626" },
-  relationships: { bg: "rgba(244, 63, 94, 0.1)", text: "#e11d48" },
-  growth: { bg: "rgba(245, 158, 11, 0.1)", text: "#d97706" },
-  finances: { bg: "rgba(16, 185, 129, 0.1)", text: "#059669" },
-  life: { bg: "rgba(139, 92, 246, 0.1)", text: "#7c3aed" },
-};
-
 const cardVariants = {
   hidden: { opacity: 0, y: 12 },
   visible: (i: number) =>
@@ -98,7 +89,7 @@ export default function TimelinePage() {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-pulse text-gray-400">Loading timeline...</div>
+        <div className="animate-pulse text-gray-400 dark:text-gray-500">Loading timeline...</div>
       </div>
     );
   }
@@ -123,10 +114,10 @@ export default function TimelinePage() {
           className="glass-card rounded-[20px] p-4"
         >
           <div className="flex items-center justify-between mb-3">
-            <h2 className="text-[10px] font-semibold text-gray-400 uppercase tracking-[0.12em]">
+            <h2 className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-[0.12em]">
               Inbox
             </h2>
-            <span className="text-[10px] font-semibold text-gray-400 bg-black/5 px-2 py-0.5 rounded-full">
+            <span className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 bg-black/5 dark:bg-white/5 px-2 py-0.5 rounded-full">
               {inboxTasks.length}
             </span>
           </div>
@@ -145,7 +136,7 @@ export default function TimelinePage() {
               <input
                 type="text"
                 placeholder="+ Add to inbox..."
-                className="w-full bg-transparent border-none text-sm py-1.5 focus:ring-0 placeholder:text-gray-300 italic"
+                className="w-full bg-transparent border-none text-sm py-1.5 focus:ring-0 placeholder:text-gray-300 dark:placeholder:text-gray-600 italic"
                 onKeyDown={(e) => handleQuickAdd(e, null)}
               />
               <div className="input-underline" />
@@ -184,17 +175,17 @@ export default function TimelinePage() {
                       <div className="flex flex-col">
                         <span
                           className={`text-[10px] font-semibold tracking-[0.12em] uppercase ${
-                            isTodayDate ? "text-violet-600" : "text-gray-400"
+                            isTodayDate ? "text-violet-600 dark:text-violet-400" : "text-gray-400 dark:text-gray-500"
                           }`}
                         >
                           {isTodayDate ? "Today" : formatDate(date).split(",")[0]}
                         </span>
-                        <span className="text-[22px] font-bold text-gray-900 leading-tight tracking-tight">
+                        <span className="text-[22px] font-bold text-gray-900 dark:text-gray-100 leading-tight tracking-tight">
                           {formatDate(date).split(",")[1]?.trim() || formatDate(date)}
                         </span>
                       </div>
                       {unresolvedCount > 0 && (
-                        <span className="bg-red-100/80 text-red-600 text-[10px] px-2.5 py-0.5 rounded-full font-semibold">
+                        <span className="bg-red-100/80 dark:bg-red-900/30 text-red-600 dark:text-red-400 text-[10px] px-2.5 py-0.5 rounded-full font-semibold">
                           {unresolvedCount} unresolved
                         </span>
                       )}
@@ -215,7 +206,7 @@ export default function TimelinePage() {
                         {priorities.map((p) => (
                           <div
                             key={p.id}
-                            className="flex-shrink-0 flex items-center gap-1 bg-amber-50/80 border border-amber-200/50 rounded-full px-3 py-1 text-[10px] font-semibold text-amber-700"
+                            className="flex-shrink-0 flex items-center gap-1 bg-amber-50/80 dark:bg-amber-900/20 border border-amber-200/50 dark:border-amber-700/30 rounded-full px-3 py-1 text-[10px] font-semibold text-amber-700 dark:text-amber-400"
                           >
                             <Star size={10} className="fill-amber-400 text-amber-400" />
                             <span className="truncate max-w-[120px]">{p.text}</span>
@@ -225,7 +216,7 @@ export default function TimelinePage() {
                     )}
 
                     {dayTasks.length === 0 ? (
-                      <p className="text-xs text-gray-400 italic py-1.5">No tasks planned</p>
+                      <p className="text-xs text-gray-400 dark:text-gray-500 italic py-1.5">No tasks planned</p>
                     ) : (
                       <div className="space-y-0.5">
                         {dayTasks.map((task) => (
@@ -250,22 +241,22 @@ export default function TimelinePage() {
                         transition={{ duration: 0.25, ease: "easeInOut" }}
                         className="overflow-hidden"
                       >
-                        <div className="mt-3 pt-4 border-t border-black/5 space-y-5">
+                        <div className="mt-3 pt-4 border-t border-black/5 dark:border-white/5 space-y-5">
                           <div>
-                            <h3 className="text-[10px] font-semibold text-gray-400 uppercase tracking-[0.12em] mb-3">
+                            <h3 className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-[0.12em] mb-3">
                               Top Priorities
                             </h3>
                             <div className="space-y-1.5">
                               {priorities.length === 0 ? (
-                                <p className="text-[10px] text-gray-400 italic">No priorities set. Tap the star on a task to prioritize.</p>
+                                <p className="text-[10px] text-gray-400 dark:text-gray-500 italic">No priorities set. Tap the star on a task to prioritize.</p>
                               ) : (
                                 priorities.map((p) => (
                                   <div
                                     key={p.id}
-                                    className="flex items-center gap-2.5 bg-amber-50/60 border border-amber-200/40 rounded-xl p-2.5"
+                                    className="flex items-center gap-2.5 bg-amber-50/60 dark:bg-amber-900/15 border border-amber-200/40 dark:border-amber-700/20 rounded-xl p-2.5"
                                   >
                                     <Star size={14} className="fill-amber-400 text-amber-400 flex-shrink-0" />
-                                    <span className="text-xs font-medium text-amber-900">{p.text}</span>
+                                    <span className="text-xs font-medium text-amber-900 dark:text-amber-300">{p.text}</span>
                                   </div>
                                 ))
                               )}
@@ -273,19 +264,19 @@ export default function TimelinePage() {
                           </div>
 
                           <div>
-                            <h3 className="text-[10px] font-semibold text-gray-400 uppercase tracking-[0.12em] mb-3">
+                            <h3 className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-[0.12em] mb-3">
                               Today&apos;s Schedule
                             </h3>
                             <div className="space-y-1">
                               {["09:00", "12:00", "15:00", "18:00"].map((time) => (
                                 <div
                                   key={time}
-                                  className="flex items-center gap-3 py-2 border-b border-black/5"
+                                  className="flex items-center gap-3 py-2 border-b border-black/5 dark:border-white/5"
                                 >
-                                  <span className="text-[10px] font-semibold text-gray-400 w-10">
+                                  <span className="text-[10px] font-semibold text-gray-400 dark:text-gray-500 w-10">
                                     {time}
                                   </span>
-                                  <div className="flex-1 h-6 bg-black/[0.03] rounded-lg border border-dashed border-black/10" />
+                                  <div className="flex-1 h-6 bg-black/[0.03] dark:bg-white/[0.04] rounded-lg border border-dashed border-black/10 dark:border-white/10" />
                                 </div>
                               ))}
                             </div>
@@ -299,7 +290,7 @@ export default function TimelinePage() {
                       <input
                         type="text"
                         placeholder={`+ Add task for ${isTodayDate ? "today" : formatDate(date).split(",")[1]?.trim() || date}...`}
-                        className="w-full bg-transparent border-none text-sm py-1.5 focus:ring-0 placeholder:text-gray-300 italic"
+                        className="w-full bg-transparent border-none text-sm py-1.5 focus:ring-0 placeholder:text-gray-300 dark:placeholder:text-gray-600 italic"
                         onKeyDown={(e) => handleQuickAdd(e, date)}
                       />
                       <div className="input-underline" />
@@ -357,7 +348,7 @@ function TaskRow({
       }}
       transition={{ type: "spring", stiffness: 200, damping: 20 }}
       className={`flex items-center gap-3 rounded-xl px-3 py-2 transition-colors ${
-        isHovered ? "bg-black/[0.03]" : ""
+        isHovered ? "bg-black/[0.03] dark:bg-white/[0.04]" : ""
       }`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
@@ -366,7 +357,7 @@ function TaskRow({
         onClick={() => (isCompleted ? onUndone(task.id) : onDone(task.id))}
         className="w-[18px] h-[18px] rounded-full border-2 flex-shrink-0 flex items-center justify-center transition-all relative"
         style={{
-          borderColor: isCompleted ? "#7c3aed" : "#d1d5db",
+          borderColor: isCompleted ? "#7c3aed" : "var(--text-subtle)",
           background: isCompleted ? "#7c3aed" : "transparent",
         }}
         aria-label={isCompleted ? "Undo complete" : "Complete task"}
@@ -385,7 +376,7 @@ function TaskRow({
       <motion.span
         animate={{
           textDecoration: isCompleted ? "line-through" : "none",
-          color: isCompleted ? "rgba(107, 114, 128, 0.6)" : "#1f2937",
+          color: isCompleted ? "rgba(107, 114, 128, 0.6)" : "var(--text-primary)",
         }}
         className="text-sm flex-1 truncate"
         style={{ fontWeight: 450 }}
@@ -396,7 +387,7 @@ function TaskRow({
       <button
         onClick={onTogglePriority}
         className={`transition-colors flex-shrink-0 ${
-          task.is_priority ? "text-amber-400" : "text-gray-200 hover:text-gray-400"
+          task.is_priority ? "text-amber-400" : "text-gray-200 dark:text-gray-600 hover:text-gray-400 dark:hover:text-gray-400"
         }`}
         aria-label={task.is_priority ? "Unmark priority" : "Mark priority"}
       >
@@ -412,8 +403,8 @@ function TaskRow({
           onClick={() => setShowAreaPicker(!showAreaPicker)}
           className="text-[10px] font-semibold px-2 py-0.5 rounded-full transition-colors"
           style={{
-            background: task.area ? AREA_COLORS[task.area].bg : "rgba(0,0,0,0.04)",
-            color: task.area ? AREA_COLORS[task.area].text : "rgba(156, 163, 175, 1)",
+            background: task.area ? `var(--area-${task.area}-bg)` : "var(--badge-bg)",
+            color: task.area ? `var(--area-${task.area}-text)` : "var(--btn-default-text)",
           }}
         >
           {task.area || "Area"}
@@ -433,7 +424,7 @@ function TaskRow({
       <div className="relative" ref={menuRef}>
         <button
           onClick={() => setShowMenu(!showMenu)}
-          className={`text-gray-300 hover:text-gray-500 transition-all flex-shrink-0 ${
+          className={`text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 transition-all flex-shrink-0 ${
             isHovered || showMenu ? "opacity-100" : "opacity-0"
           }`}
           aria-label="Task actions"
@@ -447,14 +438,14 @@ function TaskRow({
                 onUpdate(task.id, { scheduled_date: today, status: "scheduled" });
                 setShowMenu(false);
               }}
-              className="flex items-center gap-2.5 w-full text-left px-3 py-2 text-xs font-medium text-gray-600 hover:bg-black/[0.03] transition-colors"
+              className="flex items-center gap-2.5 w-full text-left px-3 py-2 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-black/[0.03] dark:hover:bg-white/[0.04] transition-colors"
             >
               Move to Today
             </button>
             <div className="relative">
               <button
                 onClick={() => setShowDatePicker(!showDatePicker)}
-                className="flex items-center gap-2.5 w-full text-left px-3 py-2 text-xs font-medium text-gray-600 hover:bg-black/[0.03] transition-colors"
+                className="flex items-center gap-2.5 w-full text-left px-3 py-2 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-black/[0.03] dark:hover:bg-white/[0.04] transition-colors"
               >
                 Pick Date
               </button>
@@ -462,7 +453,7 @@ function TaskRow({
                 <div className="absolute left-full top-0 ml-2 z-50 glass-card-strong rounded-xl p-2 shadow-lg">
                   <input
                     type="date"
-                    className="text-xs border border-black/10 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-violet-500 bg-white/80"
+                    className="text-xs border border-black/10 dark:border-white/10 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-violet-500 bg-white/80 dark:bg-gray-800/80 text-gray-800 dark:text-gray-200"
                     onChange={(e) => {
                       if (e.target.value) {
                         onUpdate(task.id, { scheduled_date: e.target.value, status: "scheduled" });
@@ -479,18 +470,18 @@ function TaskRow({
                 onUpdate(task.id, { scheduled_date: null, status: "inbox" });
                 setShowMenu(false);
               }}
-              className="flex items-center gap-2.5 w-full text-left px-3 py-2 text-xs font-medium text-gray-600 hover:bg-black/[0.03] transition-colors"
+              className="flex items-center gap-2.5 w-full text-left px-3 py-2 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-black/[0.03] dark:hover:bg-white/[0.04] transition-colors"
             >
               Move to Backlog
             </button>
-            <div className="border-t border-black/5 my-1" />
+            <div className="border-t border-black/5 dark:border-white/5 my-1" />
             <button
               onClick={() => {
                 if (isCompleted) onUndone(task.id);
                 else onDone(task.id);
                 setShowMenu(false);
               }}
-              className="flex items-center gap-2.5 w-full text-left px-3 py-2 text-xs font-medium text-gray-600 hover:bg-black/[0.03] transition-colors"
+              className="flex items-center gap-2.5 w-full text-left px-3 py-2 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-black/[0.03] dark:hover:bg-white/[0.04] transition-colors"
             >
               {isCompleted ? "Mark Undone" : "Mark Complete"}
             </button>
@@ -499,7 +490,7 @@ function TaskRow({
                 onUpdate(task.id, { status: "archived" });
                 setShowMenu(false);
               }}
-              className="flex items-center gap-2.5 w-full text-left px-3 py-2 text-xs font-medium text-red-500 hover:bg-red-50/50 transition-colors"
+              className="flex items-center gap-2.5 w-full text-left px-3 py-2 text-xs font-medium text-red-500 dark:text-red-400 hover:bg-red-50/50 dark:hover:bg-red-900/20 transition-colors"
             >
               Archive
             </button>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -23,13 +23,13 @@ export function AppShell({ children, title, headerActions, fullWidth, onAdd }: A
       <DesktopSidebar onSignOut={signOut} />
 
       <div className="md:ml-[220px] flex flex-col min-h-screen">
-        <header className="glass-card-strong border-b border-white/30 px-5 py-3 flex items-center justify-between rounded-none">
-          <h1 className="text-[15px] font-bold text-gray-800 tracking-tight">{title}</h1>
+        <header className="glass-card-strong border-b border-white/30 dark:border-white/5 px-5 py-3 flex items-center justify-between rounded-none">
+          <h1 className="text-[15px] font-bold text-gray-800 dark:text-gray-200 tracking-tight">{title}</h1>
           <div className="flex items-center gap-3">
             {headerActions}
             <button
               onClick={signOut}
-              className="text-xs text-gray-400 hover:text-gray-600 md:hidden transition-colors"
+              className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 md:hidden transition-colors"
             >
               Sign Out
             </button>

--- a/src/components/BalanceRing.tsx
+++ b/src/components/BalanceRing.tsx
@@ -44,7 +44,7 @@ export function BalanceRing({ counts, modeLabel, statLabel, statSub }: BalanceRi
 
   return (
     <div className="glass-card rounded-[20px] p-5">
-      <p className="text-xs text-gray-500 text-center mb-4 min-h-[32px]">
+      <p className="text-xs text-gray-500 dark:text-gray-400 text-center mb-4 min-h-[32px]">
         {modeLabel}
       </p>
 
@@ -55,7 +55,7 @@ export function BalanceRing({ counts, modeLabel, statLabel, statSub }: BalanceRi
             cy="80"
             r="60"
             fill="none"
-            stroke="rgba(0,0,0,0.06)"
+            stroke="var(--ring-bg)"
             strokeWidth="18"
           />
           {total > 0 && segments.map(({ area, arc, offset: segOffset }) => (
@@ -78,13 +78,13 @@ export function BalanceRing({ counts, modeLabel, statLabel, statSub }: BalanceRi
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
           {total === 0 ? (
             <>
-              <div className="text-2xl font-medium text-gray-400">—</div>
-              <div className="text-xs text-gray-400">no items</div>
+              <div className="text-2xl font-medium text-gray-400 dark:text-gray-500">—</div>
+              <div className="text-xs text-gray-400 dark:text-gray-500">no items</div>
             </>
           ) : (
             <>
-              <div className="text-2xl font-medium text-gray-900">{total}</div>
-              <div className="text-xs text-gray-500">items</div>
+              <div className="text-2xl font-medium text-gray-900 dark:text-gray-100">{total}</div>
+              <div className="text-xs text-gray-500 dark:text-gray-400">items</div>
             </>
           )}
         </div>
@@ -92,7 +92,7 @@ export function BalanceRing({ counts, modeLabel, statLabel, statSub }: BalanceRi
 
       <div className="flex flex-wrap justify-center gap-3 mb-5">
         {areas.map(([area, count]) => (
-          <div key={area} className="flex items-center gap-1.5 text-sm text-gray-600">
+          <div key={area} className="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400">
             <div className="w-2.5 h-2.5 rounded-full" style={{ background: AREA_COLORS[area] }} />
             {AREA_LABELS[area]} — {count}
           </div>
@@ -100,15 +100,15 @@ export function BalanceRing({ counts, modeLabel, statLabel, statSub }: BalanceRi
       </div>
 
       <div className="grid grid-cols-2 gap-2">
-        <div className="bg-black/[0.03] rounded-xl px-3 py-2.5">
-          <div className="text-xs text-gray-500">{statLabel}</div>
-          <div className="text-lg font-medium text-gray-900">{total}</div>
-          <div className="text-xs text-gray-400">{statSub}</div>
+        <div className="bg-black/[0.03] dark:bg-white/[0.04] rounded-xl px-3 py-2.5">
+          <div className="text-xs text-gray-500 dark:text-gray-400">{statLabel}</div>
+          <div className="text-lg font-medium text-gray-900 dark:text-gray-100">{total}</div>
+          <div className="text-xs text-gray-400 dark:text-gray-500">{statSub}</div>
         </div>
-        <div className="bg-black/[0.03] rounded-xl px-3 py-2.5">
-          <div className="text-xs text-gray-500">Areas</div>
-          <div className="text-lg font-medium text-gray-900">{areas.length}</div>
-          <div className="text-xs text-gray-400">active</div>
+        <div className="bg-black/[0.03] dark:bg-white/[0.04] rounded-xl px-3 py-2.5">
+          <div className="text-xs text-gray-500 dark:text-gray-400">Areas</div>
+          <div className="text-lg font-medium text-gray-900 dark:text-gray-100">{areas.length}</div>
+          <div className="text-xs text-gray-400 dark:text-gray-500">active</div>
         </div>
       </div>
     </div>

--- a/src/components/DesktopSidebar.tsx
+++ b/src/components/DesktopSidebar.tsx
@@ -15,10 +15,10 @@ export function DesktopSidebar({ onSignOut }: DesktopSidebarProps) {
   return (
     <aside className="hidden md:flex md:flex-col md:w-[220px] md:fixed md:inset-y-0 glass-sidebar z-30">
       <div className="px-5 py-6">
-        <h1 className="text-lg font-bold text-gray-800 tracking-tight">
+        <h1 className="text-lg font-bold text-gray-800 dark:text-gray-200 tracking-tight">
           Balanced
         </h1>
-        <p className="text-[11px] text-gray-400 tracking-[0.08em] uppercase mt-0.5">
+        <p className="text-[11px] text-gray-400 dark:text-gray-500 tracking-[0.08em] uppercase mt-0.5">
           Work & Life
         </p>
       </div>
@@ -33,14 +33,14 @@ export function DesktopSidebar({ onSignOut }: DesktopSidebarProps) {
               href={item.href}
               className={`relative flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm transition-colors ${
                 active
-                  ? "text-violet-700 font-medium"
-                  : "text-gray-500 hover:text-gray-700"
+                  ? "text-violet-700 dark:text-violet-400 font-medium"
+                  : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
               }`}
             >
               {active && (
                 <motion.div
                   layoutId="nav-active-bg"
-                  className="absolute inset-0 rounded-xl bg-violet-50/80"
+                  className="absolute inset-0 rounded-xl bg-violet-50/80 dark:bg-violet-500/15"
                   transition={{ type: "spring", stiffness: 380, damping: 30 }}
                 />
               )}
@@ -48,14 +48,14 @@ export function DesktopSidebar({ onSignOut }: DesktopSidebarProps) {
                 <Icon
                   size={18}
                   strokeWidth={1.5}
-                  className={active ? "text-violet-600" : "text-gray-400"}
+                  className={active ? "text-violet-600 dark:text-violet-400" : "text-gray-400 dark:text-gray-500"}
                 />
                 <span>{item.label}</span>
               </span>
               {active && (
                 <motion.div
                   layoutId="nav-active-bar"
-                  className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-5 bg-violet-600 rounded-full"
+                  className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-5 bg-violet-600 dark:bg-violet-500 rounded-full"
                   transition={{ type: "spring", stiffness: 380, damping: 30 }}
                 />
               )}
@@ -67,7 +67,7 @@ export function DesktopSidebar({ onSignOut }: DesktopSidebarProps) {
       <div className="px-3 py-4">
         <button
           onClick={onSignOut}
-          className="w-full flex items-center gap-3 px-3 py-2 rounded-xl text-xs text-gray-400 hover:text-gray-600 hover:bg-black/5 transition-colors"
+          className="w-full flex items-center gap-3 px-3 py-2 rounded-xl text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
         >
           Sign Out
         </button>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -24,13 +24,15 @@ export function Navigation({ className = "" }: NavigationProps) {
               key={item.href}
               href={item.href}
               className={`flex flex-col items-center gap-0.5 px-3 py-1 rounded-lg transition-colors ${
-                active ? "text-violet-600" : "text-gray-400 hover:text-gray-600"
+                active
+                  ? "text-violet-600 dark:text-violet-400"
+                  : "text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
               }`}
             >
               <Icon
                 size={18}
                 strokeWidth={active ? 2 : 1.5}
-                className={active ? "text-violet-600" : ""}
+                className={active ? "text-violet-600 dark:text-violet-400" : ""}
               />
               <span className="text-[10px] font-semibold tracking-tight">
                 {item.label}

--- a/src/components/QuickAddButton.tsx
+++ b/src/components/QuickAddButton.tsx
@@ -48,7 +48,7 @@ export function QuickAddButton({ onAdd }: QuickAddButtonProps) {
     return (
       <button
         onClick={() => setOpen(true)}
-        className="fixed bottom-6 right-6 w-14 h-14 bg-white/80 backdrop-blur-lg text-violet-600 rounded-full shadow-lg flex items-center justify-center text-2xl font-light hover:bg-white hover:shadow-xl active:scale-95 transition-all z-50 border border-white/30"
+        className="fixed bottom-6 right-6 w-14 h-14 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg text-violet-600 dark:text-violet-400 rounded-full shadow-lg flex items-center justify-center text-2xl font-light hover:bg-white dark:hover:bg-gray-800 hover:shadow-xl active:scale-95 transition-all z-50 border border-white/30 dark:border-white/10"
         aria-label="Add task"
       >
         +
@@ -57,23 +57,23 @@ export function QuickAddButton({ onAdd }: QuickAddButtonProps) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-end sm:items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black/30 dark:bg-black/60 backdrop-blur-sm flex items-end sm:items-center justify-center z-50 p-4">
       <form
         onSubmit={handleSubmit}
         className="glass-card-strong rounded-[24px] p-6 w-full max-w-md space-y-4"
       >
-        <h2 className="text-base font-bold text-gray-800">Quick Add</h2>
+        <h2 className="text-base font-bold text-gray-800 dark:text-gray-200">Quick Add</h2>
         <input
           type="text"
           placeholder="What needs to be done?"
           value={text}
           onChange={(e) => setText(e.target.value)}
           autoFocus
-          className="w-full bg-white/60 border border-black/10 rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-violet-500/30 focus:outline-none placeholder:text-gray-300 transition-all"
+          className="w-full bg-white/60 dark:bg-gray-800/60 border border-black/10 dark:border-white/10 rounded-xl px-4 py-2.5 text-sm text-gray-800 dark:text-gray-200 focus:ring-2 focus:ring-violet-500/30 focus:outline-none placeholder:text-gray-300 dark:placeholder:text-gray-500 transition-all"
         />
 
         <div>
-          <label className="text-xs text-gray-500 block mb-1.5 font-medium">When</label>
+          <label className="text-xs text-gray-500 dark:text-gray-400 block mb-1.5 font-medium">When</label>
           <div className="flex gap-2 flex-wrap">
             {(["today", "tomorrow", "custom", "none"] as WhenOption[]).map((opt) => {
               const today = getToday();
@@ -89,8 +89,8 @@ export function QuickAddButton({ onAdd }: QuickAddButtonProps) {
                   onClick={() => setWhen(opt)}
                   className={`text-xs px-3 py-1.5 rounded-xl border transition-all ${
                     when === opt
-                      ? "bg-violet-100/80 border-violet-200 text-violet-700 font-medium"
-                      : "border-black/10 text-gray-500 hover:bg-white/60"
+                      ? "bg-violet-100/80 dark:bg-violet-500/20 border-violet-200 dark:border-violet-500/30 text-violet-700 dark:text-violet-400 font-medium"
+                      : "border-black/10 dark:border-white/10 text-gray-500 dark:text-gray-400 hover:bg-white/60 dark:hover:bg-gray-800/60"
                   }`}
                 >
                   {label}
@@ -103,13 +103,13 @@ export function QuickAddButton({ onAdd }: QuickAddButtonProps) {
               type="date"
               value={customDate}
               onChange={(e) => setCustomDate(e.target.value)}
-              className="mt-2 w-full bg-white/60 border border-black/10 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-violet-500/30 focus:outline-none"
+              className="mt-2 w-full bg-white/60 dark:bg-gray-800/60 border border-black/10 dark:border-white/10 rounded-xl px-3 py-2 text-sm text-gray-800 dark:text-gray-200 focus:ring-2 focus:ring-violet-500/30 focus:outline-none"
             />
           )}
         </div>
 
         <div>
-          <label className="text-xs text-gray-500 block mb-1.5 font-medium">Area</label>
+          <label className="text-xs text-gray-500 dark:text-gray-400 block mb-1.5 font-medium">Area</label>
           <div className="flex gap-2 flex-wrap">
             {AREAS.map(({ value, label }) => (
               <button
@@ -118,8 +118,8 @@ export function QuickAddButton({ onAdd }: QuickAddButtonProps) {
                 onClick={() => setArea(value)}
                 className={`text-xs px-3 py-1.5 rounded-xl border transition-all ${
                   area === value
-                    ? "bg-violet-100/80 border-violet-200 text-violet-700 font-medium"
-                    : "border-black/10 text-gray-500 hover:bg-white/60"
+                    ? "bg-violet-100/80 dark:bg-violet-500/20 border-violet-200 dark:border-violet-500/30 text-violet-700 dark:text-violet-400 font-medium"
+                    : "border-black/10 dark:border-white/10 text-gray-500 dark:text-gray-400 hover:bg-white/60 dark:hover:bg-gray-800/60"
                 }`}
               >
                 {label}
@@ -132,7 +132,7 @@ export function QuickAddButton({ onAdd }: QuickAddButtonProps) {
           <button
             type="button"
             onClick={() => setOpen(false)}
-            className="flex-1 py-2.5 border border-black/10 rounded-xl text-sm text-gray-500 hover:bg-white/60 transition-all"
+            className="flex-1 py-2.5 border border-black/10 dark:border-white/10 rounded-xl text-sm text-gray-500 dark:text-gray-400 hover:bg-white/60 dark:hover:bg-gray-800/60 transition-all"
           >
             Cancel
           </button>

--- a/src/components/brainstorm/AreaPicker.tsx
+++ b/src/components/brainstorm/AreaPicker.tsx
@@ -4,12 +4,12 @@ import { useEffect, useRef } from "react";
 import { LifeArea } from "@/lib/types";
 
 const AREAS: { value: LifeArea; label: string; color: string }[] = [
-  { value: "work", label: "Work", color: "text-blue-700" },
-  { value: "life", label: "Life", color: "text-green-700" },
-  { value: "health", label: "Health", color: "text-red-700" },
-  { value: "relationships", label: "Relationships", color: "text-pink-700" },
-  { value: "growth", label: "Growth", color: "text-amber-700" },
-  { value: "finances", label: "Finances", color: "text-emerald-700" },
+  { value: "work", label: "Work", color: "text-blue-700 dark:text-blue-300" },
+  { value: "life", label: "Life", color: "text-green-700 dark:text-green-300" },
+  { value: "health", label: "Health", color: "text-red-700 dark:text-red-300" },
+  { value: "relationships", label: "Relationships", color: "text-pink-700 dark:text-pink-300" },
+  { value: "growth", label: "Growth", color: "text-amber-700 dark:text-amber-300" },
+  { value: "finances", label: "Finances", color: "text-emerald-700 dark:text-emerald-300" },
 ];
 
 interface AreaPickerProps {
@@ -32,13 +32,13 @@ export function AreaPicker({ current, onSelect, onClose }: AreaPickerProps) {
   return (
     <div
       ref={ref}
-      className="absolute right-0 top-full mt-1 z-50 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[140px]"
+      className="absolute right-0 top-full mt-1 z-50 glass-card-strong rounded-xl py-1 min-w-[140px] shadow-lg"
     >
       {AREAS.map(({ value, label, color }) => (
         <button
           key={value}
           onClick={() => onSelect(value)}
-          className={`block w-full text-left text-sm px-3 py-1.5 hover:bg-gray-50 ${
+          className={`block w-full text-left text-sm px-3 py-1.5 hover:bg-black/[0.03] dark:hover:bg-white/[0.06] ${
             current === value ? "font-medium" : ""
           } ${color}`}
         >
@@ -48,7 +48,7 @@ export function AreaPicker({ current, onSelect, onClose }: AreaPickerProps) {
       {current && (
         <button
           onClick={() => onSelect(null)}
-          className="block w-full text-left text-sm px-3 py-1.5 hover:bg-gray-50 text-gray-400 italic border-t border-gray-100 mt-1"
+          className="block w-full text-left text-sm px-3 py-1.5 hover:bg-black/[0.03] dark:hover:bg-white/[0.06] text-gray-400 dark:text-gray-500 italic border-t border-black/5 dark:border-white/5 mt-1"
         >
           Clear
         </button>

--- a/src/components/brainstorm/IdeaNode.tsx
+++ b/src/components/brainstorm/IdeaNode.tsx
@@ -47,20 +47,20 @@ function formatScheduleDate(date: string, today: string): string {
 }
 
 const TYPE_COLORS: Record<IdeaType, string> = {
-  idea: "bg-orange-50 text-orange-700 border-orange-200",
-  objective: "bg-purple-50 text-purple-700 border-purple-200",
-  project: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  initiative: "bg-amber-50 text-amber-700 border-amber-200",
-  task: "bg-blue-50 text-blue-700 border-blue-200",
+  idea: "bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-300 border-orange-200 dark:border-orange-700/30",
+  objective: "bg-purple-50 dark:bg-purple-900/20 text-purple-700 dark:text-purple-300 border-purple-200 dark:border-purple-700/30",
+  project: "bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-700/30",
+  initiative: "bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-700/30",
+  task: "bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-700/30",
 };
 
 const AREA_COLORS: Record<LifeArea, string> = {
-  work: "bg-blue-50 text-blue-700 border-blue-200",
-  health: "bg-red-50 text-red-700 border-red-200",
-  relationships: "bg-pink-50 text-pink-700 border-pink-200",
-  growth: "bg-amber-50 text-amber-700 border-amber-200",
-  finances: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  life: "bg-green-50 text-green-700 border-green-200",
+  work: "bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-700/30",
+  health: "bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border-red-200 dark:border-red-700/30",
+  relationships: "bg-pink-50 dark:bg-pink-900/20 text-pink-700 dark:text-pink-300 border-pink-200 dark:border-pink-700/30",
+  growth: "bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-700/30",
+  finances: "bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-700/30",
+  life: "bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300 border-green-200 dark:border-green-700/30",
 };
 
 export function IdeaNode({


### PR DESCRIPTION
## Summary

Automatic dark mode that follows the system `prefers-color-scheme` media query. No toggle needed — it just works when the user switches their OS to dark mode.

## How it works

- CSS custom properties on `:root` define all colors (glass surfaces, text, meshes, badges, dividers, scrollbar, area tags)
- A `@media (prefers-color-scheme: dark)` block overrides every variable with dark-mode-appropriate values
- Tailwind `dark:` variants added to all components for text colors, backgrounds, borders, and hover states
- Glass surface backgrounds switch from white-based to dark navy-based (`rgba(30,30,48,0.55)`)
- Background mesh blobs dim to lower opacity (violet 0.12, sky 0.08, indigo 0.1)
- Text colors invert (gray-800 → gray-200, gray-500 → gray-400, etc.)
- Area tag pills use darker, translucent backgrounds with lighter text (e.g. `rgba(139,92,246,0.2)` with `#a78bfa`)
- `color-scheme: light dark` set on `:root` for native dark scrollbars

## Files changed

All 12 files updated with `dark:` classes or CSS variable references — no logic or behavior changes.